### PR TITLE
[ add ] タスクの入力状態をフックで実装

### DIFF
--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -1,4 +1,5 @@
-import { FC, useState } from "react";
+import { FC } from "react";
+import { useUserTaskInput } from "../hooks/useUserTaskInput";
 
 type Props = {
   addTask: (title: string) => void;
@@ -7,23 +8,8 @@ type Props = {
 /* タスクの入力と追加を担当するコンポーネント */
 
 export const TaskInput: FC<Props> = ({ addTask }) => {
-
-  // テキストボックスに入力された値はユーザによって変化する→useStateで定義
-  const [task, setTask] = useState("");
-
-  // テキストボックスに入力された値をtaskに設定する処理
-  const handleInputTask = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setTask(event.target.value);
-  };
-
-  // フォーム要素内の追加ボタンを押したときの処理
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (task.trim()) {
-      addTask(task);
-      setTask("");
-    }
-  };
+  const { taskInput, handleInputChange, handleSubmit } = useUserTaskInput(addTask);
+  
 
   return (
     <>
@@ -33,8 +19,8 @@ export const TaskInput: FC<Props> = ({ addTask }) => {
             className="border-2 border-gray-300 rounded-md focus:border-orange-200 outline-none p-3 w-2/3 lg:w-4/5 placeholder-shown:border-gray-50"
             type="text"
             placeholder="タスクを追加"
-            value={task}
-            onChange={handleInputTask}
+            value={taskInput}
+            onChange={handleInputChange}
           />
           <button
             type="submit"

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,13 +1,13 @@
 import { FC } from "react";
 import { TaskInput } from "./TaskInput";
 import { TaskList } from "./TaskList";
-import { useTaskList } from "../hooks/userTaskList";
+import { useUserTaskList } from "../hooks/useUserTaskList";
 
 /* タスク関連を管理するコンポーネント */
 
 export const TaskManager: FC = () => {
-  const {tasks, addTask} = useTaskList();
-
+  const {tasks, addTask} = useUserTaskList();
+  
   return (
     <>
         <TaskInput addTask={addTask}  />

--- a/src/hooks/useUserTaskInput.tsx
+++ b/src/hooks/useUserTaskInput.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+
+interface useUserTaskInputReturn {
+  taskInput: string;
+  handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleSubmit: (event: React.FormEvent) => void;
+}
+
+export const useUserTaskInput = (
+  addTask: (title: string) => void
+): useUserTaskInputReturn => {
+  const [taskInput, setTaskInput] = useState("");
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setTaskInput(event.target.value);
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (taskInput.trim()) {
+      addTask(taskInput);
+      setTaskInput("");
+    }
+  };
+
+  return {
+    taskInput,
+    handleInputChange,
+    handleSubmit,
+  };
+};

--- a/src/hooks/useUserTaskList.tsx
+++ b/src/hooks/useUserTaskList.tsx
@@ -1,26 +1,19 @@
 import { useState } from "react";
-
-type Task = {
-  id: number;
-  title: string;
-};
+import { Task } from "../types";
 
 //userTaskListの戻り値の型定義
-interface UserTaskListReturn {
+interface useUserTaskListReturn {
   tasks: Task[];
   addTask: (title: string) => void;
 }
 
-export const useTaskList = (): UserTaskListReturn => {
-
-  // 表示するタスクはユーザによって変化する→useStateで定義
+export const useUserTaskList = (): useUserTaskListReturn => {
   const [tasks, setTasks] = useState<Task[]>([]);
 
-  // 新しいタスクを追加する関数
   const addTask = (title: string) => {
-    // 新しいタスクのプロパティ
+    if (!title.trim()) return;
     const newTask: Task = {
-      id: tasks.length + 1,
+      id: tasks.length > 0 ? Math.max(...tasks.map((task) => task.id)) + 1 : 1,
       title,
     };
     setTasks([...tasks, newTask]);


### PR DESCRIPTION
TaskInputコンポーネントには、Viewとロジックが存在していた。
useUserTaskInputフックに、ロジックを分離した。