### PR TITLE
[ update ] カスタムフックの名前を変更

### DIFF
--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { useUserTaskInput } from "../hooks/useUserTaskInput";
+import { useTaskInput } from "../hooks/useTaskInput";
 
 type Props = {
   addTask: (title: string) => void;
@@ -8,7 +8,7 @@ type Props = {
 /* タスクの入力と追加を担当するコンポーネント */
 
 export const TaskInput: FC<Props> = ({ addTask }) => {
-  const { taskInput, handleInputChange, handleSubmit } = useUserTaskInput(addTask);
+  const { taskInput, handleInputChange, handleSubmit } = useTaskInput(addTask);
   
 
   return (

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,12 +1,12 @@
 import { FC } from "react";
 import { TaskInput } from "./TaskInput";
 import { TaskList } from "./TaskList";
-import { useUserTaskList } from "../hooks/useUserTaskList";
+import { useTaskList } from "../hooks/useTaskList";
 
 /* タスク関連を管理するコンポーネント */
 
 export const TaskManager: FC = () => {
-  const {tasks, addTask} = useUserTaskList();
+  const {tasks, addTask} = useTaskList();
   
   return (
     <>

--- a/src/hooks/useTaskInput.tsx
+++ b/src/hooks/useTaskInput.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 
-interface useUserTaskInputReturn {
+interface useTaskInputReturn {
   taskInput: string;
   handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleSubmit: (event: React.FormEvent) => void;
 }
 
-export const useUserTaskInput = (
+export const useTaskInput = (
   addTask: (title: string) => void
-): useUserTaskInputReturn => {
+): useTaskInputReturn => {
   const [taskInput, setTaskInput] = useState("");
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/hooks/useTaskList.tsx
+++ b/src/hooks/useTaskList.tsx
@@ -2,12 +2,12 @@ import { useState } from "react";
 import { Task } from "../types";
 
 //userTaskListの戻り値の型定義
-interface useUserTaskListReturn {
+interface useTaskListReturn {
   tasks: Task[];
   addTask: (title: string) => void;
 }
 
-export const useUserTaskList = (): useUserTaskListReturn => {
+export const useTaskList = (): useTaskListReturn => {
   const [tasks, setTasks] = useState<Task[]>([]);
 
   const addTask = (title: string) => {


### PR DESCRIPTION
タスクの入力状態を管理するフックをuseUserTaskInputからuseTaskInput、タスクリストに表示するタスクの状態を管理するフックをuseUserTaskListからuseTaskListに変更。それに伴い、適宜インポート名も変更。