### PR TITLE
[ add ] スコア管理コンポーネントの作成

### DIFF
--- a/src/components/ScoreManager.tsx
+++ b/src/components/ScoreManager.tsx
@@ -1,0 +1,14 @@
+import { Score } from "../types";
+import { DisplayScoreBoard } from "./DisplayScoreBoard";
+
+export const ScoreManager = () => {
+  const score: Score[] = [
+    { score: 1, label: "タスク進捗スコア", color: "bg-green-100" },
+    { score: 2, label: "全タスク数-1スコア", color: "bg-red-200" },
+  ];
+  return (
+    <>
+      <DisplayScoreBoard scores={score} />
+    </>
+  );
+};

--- a/src/components/Tastle.tsx
+++ b/src/components/Tastle.tsx
@@ -1,19 +1,14 @@
 import { Title } from "./Title";
-import { Score } from "../types";
-import { DisplayScoreBoard } from "./DisplayScoreBoard";
 import { TaskManager } from "./TaskManager";
+import { ScoreManager } from "./ScoreManager";
 
 export const Tastle = () => {
-  const score: Score[] = [
-    { score: 1, label: "タスク進捗スコア", color: "bg-green-100" },
-    { score: 2, label: "全タスク数-1スコア", color: "bg-red-200" },
-  ];
 
   return (
     <main className="flex flex-col items-center p-8 bg-blue-50 min-h-screen">
       <Title />
       <TaskManager />
-      <DisplayScoreBoard scores={score} />
+      <ScoreManager />
     </main>
   );
 };


### PR DESCRIPTION
Tastleコンポーネントでべた書きしていたスコアデータをScoreManagerコンポーネントに移動。