### PR TITLE
[ update] タスクの完了状態とスコア更新の実装

### DIFF
--- a/src/components/Tastle.tsx
+++ b/src/components/Tastle.tsx
@@ -11,17 +11,27 @@ export const Tastle = () => {
 
   const handleToggleTask = (taskId: number) => {
     const completed = toggleTaskCompletion(taskId); // タスクの新しい完了状態を取得
-    updateScore("タスク遂行スコア", tasks, completed); // 完了状態に応じてスコアを変更
-    updateScore("全タスク-1スコア", tasks);
+    if (completed !== undefined) {
+      // タスク遂行スコアを更新
+      updateScore("タスク遂行スコア", tasks, !completed, completed);
+    }
   };
-  
+
+  const handleAddTask = (title: string) => {
+    addTask(title); // タスクを追加
+  };
+
+  const handleDeleteTask = (taskId: number) => {
+    deleteTask(taskId); // タスクを削除
+  };
+
   return (
     <main className="flex flex-col items-center p-8 bg-blue-50 min-h-screen">
       <Title />
-      <TaskInput addTask={addTask} />
+      <TaskInput addTask={handleAddTask} />
       <TaskList
         tasks={tasks}
-        deleteTask={deleteTask}
+        deleteTask={handleDeleteTask}
         toggleTaskCompletion={handleToggleTask}
       />
       <ScoreBoard scores={scores} />

--- a/src/hooks/useScore.tsx
+++ b/src/hooks/useScore.tsx
@@ -20,17 +20,20 @@ export const useScore = () => {
   const updateScore = (
     label: string,
     tasks: { id: number; completed: boolean }[],
-    completed?: boolean
+    previousCompleted?: boolean,
+    currentCompleted?: boolean
   ) => {
     setScores((prevScores) =>
       prevScores.map((score) => {
         if (score.label === label) {
-          if (label === "タスク遂行スコア" && completed !== undefined) {
+          if (label === "タスク遂行スコア") {
             // タスク遂行スコア: 完了した場合 +1、未完了の場合 -1
-            return {
-              ...score,
-              score: score.score + (completed === true ? 1 : -1),
-            };
+            if (previousCompleted === false && currentCompleted === true) {
+              return { ...score, score: score.score + 1 };
+            }
+            if (previousCompleted === true && currentCompleted === false) {
+              return { ...score, score: score.score - 1 };
+            }
           }
 
           if (label === "全タスク-1スコア") {

--- a/src/hooks/useTaskList.tsx
+++ b/src/hooks/useTaskList.tsx
@@ -7,12 +7,13 @@ interface useTaskListReturn {
   tasks: Task[];
   addTask: (title: string) => void;
   deleteTask: (taskId: number) => void;
-  toggleTaskCompletion: (taskId: number) => boolean;
+  toggleTaskCompletion: (taskId: number) => boolean | undefined;
 }
 
 export const useTaskList = (): useTaskListReturn => {
   const [tasks, setTasks] = useState<Task[]>([]);
 
+  // タスク内容を受け取り、既存のタスクデータを更新する関数
   const addTask = (title: string) => {
     if (!title.trim()) return;
     const newTask: Task = {
@@ -23,22 +24,20 @@ export const useTaskList = (): useTaskListReturn => {
     setTasks([...tasks, newTask]);
   };
 
+  // タスクidを受け取り、idと合うタスクデータを削除する関数
   const deleteTask = (taskId: number) => {
     setTasks(tasks.filter((task) => task.id !== taskId));
   };
 
-  const toggleTaskCompletion = (taskId: number): boolean => {
-    let taskCompleted = false;
-    setTasks((prevTasks) =>
-      prevTasks.map((task) => {
-        if (task.id === taskId) {
-          taskCompleted = !task.completed;
-          return { ...task, completed: taskCompleted}
-        }
-        return task;
-      })
-    );
-    return taskCompleted; // 完了状態を返す
+  const toggleTaskCompletion = (taskId: number): boolean | undefined => {
+    const taskIndex = tasks.findIndex((task) => task.id === taskId);
+    if (taskIndex !== -1) {
+      const updatedTasks = [...tasks];
+      updatedTasks[taskIndex].completed = !updatedTasks[taskIndex].completed;
+      setTasks(updatedTasks);
+      return updatedTasks[taskIndex].completed; // 新しい完了状態を返す
+    }
+    return undefined;
   };
 
   return { tasks, addTask, deleteTask, toggleTaskCompletion };


### PR DESCRIPTION
タスクの完了状態に応じてタスク遂行スコアが-1ずつ減っていかないようにした。
1つのタスクにおいて、完了→+1、未完了-1というルールにした。