### PR TITLE
[ update ] タスク完了とスコア更新の連携機能 (未完成)

### DIFF
--- a/src/components/Tastle.tsx
+++ b/src/components/Tastle.tsx
@@ -17,21 +17,13 @@ export const Tastle = () => {
     }
   };
 
-  const handleAddTask = (title: string) => {
-    addTask(title); // タスクを追加
-  };
-
-  const handleDeleteTask = (taskId: number) => {
-    deleteTask(taskId); // タスクを削除
-  };
-
   return (
     <main className="flex flex-col items-center p-8 bg-blue-50 min-h-screen">
       <Title />
-      <TaskInput addTask={handleAddTask} />
+      <TaskInput addTask={addTask} />
       <TaskList
         tasks={tasks}
-        deleteTask={handleDeleteTask}
+        deleteTask={deleteTask}
         toggleTaskCompletion={handleToggleTask}
       />
       <ScoreBoard scores={scores} />

--- a/src/hooks/useTaskList.tsx
+++ b/src/hooks/useTaskList.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { Task } from "../types";
 
-// タスクリストを構成するタスクとそのロジックを担当しているフック
-
 interface useTaskListReturn {
   tasks: Task[];
   addTask: (title: string) => void;
@@ -29,6 +27,7 @@ export const useTaskList = (): useTaskListReturn => {
     setTasks(tasks.filter((task) => task.id !== taskId));
   };
 
+  // タスクidを受け取り、idと合うタスクの完了状態を切り替える関数
   const toggleTaskCompletion = (taskId: number): boolean | undefined => {
     const taskIndex = tasks.findIndex((task) => task.id === taskId);
     if (taskIndex !== -1) {


### PR DESCRIPTION
タスク内容を受け取り、タスクリストに追加する関数はuseTaskListフック内に記述しているため、handleAddTask関数を削除。
タスクidを受け取り、idに一致するタスクをタスクリストから削除する関数はuseTaskListフック内に記述しているため、handleDelete関数を削除。
タスクの完了状態によって、スコアが更新される機能の理解を行った。