### PR TITLE
[ add ] 全タスク-1スコアを更新する関数

### DIFF
--- a/src/components/Tastle.tsx
+++ b/src/components/Tastle.tsx
@@ -9,6 +9,18 @@ export const Tastle = () => {
   const { tasks, addTask, deleteTask, toggleTaskCompletion } = useTaskList();
   const { scores, updateScore } = useScore();
 
+  const handleAddTask = (title: string) => {
+    addTask(title);
+    const updatedTasks = [...tasks, { id: Date.now(), completed: false }]; // 新しいタスクを仮追加
+    updateScore("全タスク-1スコア", updatedTasks);
+  };
+
+  const handleDeleteTask = (taskId: number) => {
+    const updatedTasks = tasks.filter((task) => task.id !== taskId); // 削除後のタスクリストを計算
+    deleteTask(taskId); // タスク削除処理
+    updateScore("全タスク-1スコア", updatedTasks); // 更新されたタスクリストを渡してスコアを更新
+  };
+
   const handleToggleTask = (taskId: number) => {
     const completed = toggleTaskCompletion(taskId); // タスクの新しい完了状態を取得
     if (completed !== undefined) {
@@ -20,10 +32,10 @@ export const Tastle = () => {
   return (
     <main className="flex flex-col items-center p-8 bg-blue-50 min-h-screen">
       <Title />
-      <TaskInput addTask={addTask} />
+      <TaskInput addTask={handleAddTask} />
       <TaskList
         tasks={tasks}
-        deleteTask={deleteTask}
+        deleteTask={handleDeleteTask}
         toggleTaskCompletion={handleToggleTask}
       />
       <ScoreBoard scores={scores} />

--- a/src/hooks/useScore.tsx
+++ b/src/hooks/useScore.tsx
@@ -39,7 +39,7 @@ export const useScore = () => {
           if (label === "全タスク-1スコア") {
             // 全タスク-1スコア: タスク数 - 1 (ただし最低値は 0)
             const taskCount = tasks.length;
-            const newScore = Math.max(0, taskCount - 1);
+            const newScore = taskCount <= 1 ? 0 : taskCount - 1;
             return { ...score, score: newScore };
           }
         }

--- a/src/hooks/useTaskList.tsx
+++ b/src/hooks/useTaskList.tsx
@@ -13,13 +13,14 @@ export const useTaskList = (): useTaskListReturn => {
 
   // タスク内容を受け取り、既存のタスクデータを更新する関数
   const addTask = (title: string) => {
-    if (!title.trim()) return;
+    if (!title) return;
     const newTask: Task = {
       id: tasks.length > 0 ? Math.max(...tasks.map((task) => task.id)) + 1 : 1,
       title,
       completed: false,
     };
-    setTasks([...tasks, newTask]);
+    const updatedTasks = [...tasks, newTask];
+    setTasks(updatedTasks);
   };
 
   // タスクidを受け取り、idと合うタスクデータを削除する関数


### PR DESCRIPTION
実装した内容：全タスク-1スコアを更新する関数を以下の関数内で実行できるようにした。
handleAddTask関数：タスクが追加されたときに、全タスク-1スコアを更新する。
handleDeleteTask関数：タスクが削除されたときに、全タスク-1スコアを更新する。